### PR TITLE
Use x86 segments for running x86-JIT on x64

### DIFF
--- a/common/include/x86emitter/x86types.h
+++ b/common/include/x86emitter/x86types.h
@@ -988,6 +988,9 @@ public:
 
     xModSibType operator[](const void *src) const
     {
+        //assert(false);
+        uintptr_t src_addr = (uintptr_t)src;
+        assert(src_addr <= 0xFFFFFFFF);
         return xModSibType((uptr)src);
     }
 };

--- a/common/src/Utilities/Linux/LnxHostSys.cpp
+++ b/common/src/Utilities/Linux/LnxHostSys.cpp
@@ -149,7 +149,7 @@ void *HostSys::MmapReservePtr(void *base, size_t size)
     // or anonymous source, with PROT_NONE (no-access) permission.  Since the mapping
     // is completely inaccessible, the OS will simply reserve it and will not put it
     // against the commit table.
-    return mmap(base, size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    return mmap(base, size, PROT_NONE, MAP_32BIT | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 }
 
 bool HostSys::MmapCommitPtr(void *base, size_t size, const PageProtectionMode &mode)
@@ -212,7 +212,7 @@ void *HostSys::Mmap(uptr base, size_t size)
 
     // MAP_ANONYMOUS - means we have no associated file handle (or device).
 
-    return mmap((void *)base, size, PROT_EXEC | PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    return mmap((void *)base, size, PROT_EXEC | PROT_READ | PROT_WRITE, MAP_32BIT | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 }
 
 void HostSys::Munmap(uptr base, size_t size)

--- a/pcsx2/x86/newVif_Dynarec.cpp
+++ b/pcsx2/x86/newVif_Dynarec.cpp
@@ -347,8 +347,11 @@ _vifT __fi void dVifUnpack(const u8* data, bool isFill) {
 
 		u8*  startmem = VU.Mem + (vif.tag.addr & (vuMemLimit-0x10));
 		u8*  endmem   = VU.Mem + vuMemLimit;
-
+#if 0
 		if (likely((startmem + b->length) <= endmem)) {
+#else
+    if(0) {
+#endif
 			// No wrapping, you can run the fast dynarec
 			((nVifrecCall)b->startPtr)((uptr)startmem, (uptr)data);
 		} else {

--- a/plugins/GSdx/Renderers/OpenGL/GSTextureOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSTextureOGL.cpp
@@ -155,8 +155,10 @@ namespace PboPool {
 GSTextureOGL::GSTextureOGL(int type, int w, int h, int format, GLuint fbo_read, bool mipmap)
 	: m_clean(false), m_generate_mipmap(true), m_local_buffer(nullptr), m_r_x(0), m_r_y(0), m_r_w(0), m_r_h(0), m_layer(0)
 {
+#if 0
 	ASSERT(w > 0);
 	ASSERT(h > 0);
+#endif
 
 	// OpenGL didn't like dimensions of size 0
 	m_size.x = std::max(1,w);


### PR DESCRIPTION
**(This is only a proof of concept at the moment)**

This attempts to use segments 0x23 / 0x2B on Linux to switch the CPU into 32-bit mode for the JIT portions.
This requires a lot of context switches and some code overhead on entry / exit.

- I've only prototyped an entry and exit function in one code path (needs more fixes).
- There's still issues because some data uses 64 bit addresses (needs a different section + linker script, or more relocations).
- These cases of invalid addresses are not caught by my asserts (more should be added).
- I did not check if PCS2X needs additional exits halfway through (calls into the host would have to be wrapped / isolated).
- The code is ugly and it could be way shorter.

---

This was inspired by https://stackoverflow.com/questions/41921711/running-32-bit-code-in-64-bit-process-on-linux-memory-access
A similar approach should work on Windows: http://blog.rewolf.pl/blog/?p=102